### PR TITLE
Python tarballs

### DIFF
--- a/projects/unix/tomviz.bundle.cmake
+++ b/projects/unix/tomviz.bundle.cmake
@@ -2,7 +2,7 @@ include(tomviz.bundle.common)
 include(CPack)
 
 # install all ParaView's shared libraries.
-install(DIRECTORY "${install_location}/lib/paraview-4.2"
+install(DIRECTORY "${install_location}/lib/paraview-4.3"
   DESTINATION "lib"
   USE_SOURCE_PERMISSIONS
   COMPONENT superbuild)

--- a/projects/win32/numpy.cmake
+++ b/projects/win32/numpy.cmake
@@ -1,0 +1,2 @@
+add_external_dummy_project(numpy
+  DEPENDS python)

--- a/projects/win32/python.install.cmake
+++ b/projects/win32/python.install.cmake
@@ -1,0 +1,5 @@
+foreach (dir bin include lib share)
+  file(GLOB files "${dir}/*")
+  file(INSTALL ${files}
+       DESTINATION "${install_dir}/${dir}")
+endforeach ()

--- a/projects/win32/tomviz.bundle.cmake
+++ b/projects/win32/tomviz.bundle.cmake
@@ -38,7 +38,7 @@ if (python_ENABLED AND NOT USE_SYSTEM_python)
 endif()
 
 # install paraview python modules and others.
-install(DIRECTORY "${install_location}/lib/paraview-4.2"
+install(DIRECTORY "${install_location}/lib/paraview-4.3"
         DESTINATION "lib"
         USE_SOURCE_PERMISSIONS
         COMPONENT ${AppName}

--- a/projects/win32/tomviz.bundle.cmake
+++ b/projects/win32/tomviz.bundle.cmake
@@ -35,18 +35,6 @@ if (python_ENABLED AND NOT USE_SYSTEM_python)
           USE_SOURCE_PERMISSIONS
           COMPONENT ${AppName}
           FILES_MATCHING PATTERN "python*.dll")
-
-  # install python pyd objects (python dlls).
-  # For 64 bit builds, these are in an amd64/ subdir
-  set(PYTHON_PCBUILD_SUBDIR "")
-  if(CMAKE_CL_64)
-    set(PYTHON_PCBUILD_SUBDIR "amd64/")
-  endif()
-  install(DIRECTORY "${SuperBuild_BINARY_DIR}/python/src/python/PCbuild/${PYTHON_PCBUILD_SUBDIR}"
-          DESTINATION "bin/Lib"
-          USE_SOURCE_PERMISSIONS
-          COMPONENT ${AppName}
-          FILES_MATCHING PATTERN "*.pyd")
 endif()
 
 # install paraview python modules and others.
@@ -62,15 +50,6 @@ install(DIRECTORY "${install_location}/lib/tomviz-${tomviz_version}"
         USE_SOURCE_PERMISSIONS
         COMPONENT ${AppName}
         PATTERN "*.lib" EXCLUDE)
-
-# install all extra Python modules/packages.
-if (numpy_ENABLED)
-  # on Windows, all Python packages simply go under bin/Lib/site-packages"
-  install(DIRECTORY "${install_location}/lib/site-packages/"
-    DESTINATION "bin/Lib/site-packages"
-    USE_SOURCE_PERMISSIONS
-    COMPONENT ${AppName})
-endif()
 
 #------------------------------------------------------------------------------
 set (CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_LIST_DIR}/InstallerIcon.ico")


### PR DESCRIPTION
---
Adds the forgotten install script and stubs out numpy on Windows (which already ships in the Python binary tarball).