### PR TITLE
windows: python bundle will contain precompiled lapack so don't build it

### DIFF
--- a/projects/win32/lapack.cmake
+++ b/projects/win32/lapack.cmake
@@ -1,0 +1,2 @@
+add_external_dummy_project(lapack
+    DEPENDS python)


### PR DESCRIPTION
@cryos This will get the windows build working again.  It still won't have scipy.  I've kicked off a Mac build with modified buildbot scripts that should be fine.