### PR TITLE
tomviz uses patch in the version number. Fixed that.

### DIFF
--- a/cmake/DetermineTomVizVersion.cmake
+++ b/cmake/DetermineTomVizVersion.cmake
@@ -18,7 +18,7 @@ function(_set_version_vars versiontext)
     set(patch ${CMAKE_MATCH_3})
     set(patch_extra ${CMAKE_MATCH_4})
 
-    set(tomviz_version "${major}.${minor}" PARENT_SCOPE)
+    set(tomviz_version "${major}.${minor}.${patch}" PARENT_SCOPE)
     set(tomviz_version_major ${major} PARENT_SCOPE)
     set(tomviz_version_minor ${minor} PARENT_SCOPE)
     set(tomviz_version_patch ${patch} PARENT_SCOPE)


### PR DESCRIPTION
This fixes Windows packaging issues. The tomviz version varible affects
Linux builds too. Not sure if those packages needed this fix too (since
we don't have Linux dashboard). I am going to assume they do.