### PR TITLE
Make sure the PV plugin library is installed on windows

### DIFF
--- a/projects/win32/tomviz.bundle.cmake
+++ b/projects/win32/tomviz.bundle.cmake
@@ -51,6 +51,11 @@ install(DIRECTORY "${install_location}/lib/tomviz"
         COMPONENT ${AppName}
         PATTERN "*.lib" EXCLUDE)
 
+# install tomviz custom PV plugin
+install(FILES "${install_location}/lib/tomvizExtensions.dll"
+        DESTINATION "bin"
+	COMPONENT ${AppName})
+
 if(itk_ENABLED)
 install(DIRECTORY "${install_location}/lib/itk"
         DESTINATION "lib"


### PR DESCRIPTION
This requires the fixup-binaries branch from the tomviz project to be in place first and fixes the windows binaries to install tomvizExtensions.dll.