### PR TITLE
Bundle itk bug real fix

### DIFF
--- a/projects/apple/tomviz.bundle.cmake
+++ b/projects/apple/tomviz.bundle.cmake
@@ -4,6 +4,7 @@ set(CPACK_GENERATOR DragNDrop)
 include(CPack)
 
 install(CODE "
+    cmake_policy(VERSION 2.8.8)
     # Install the app first.
     file(INSTALL DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\" USE_SOURCE_PERMISSIONS TYPE DIRECTORY FILES
          \"${install_location}/Applications/tomviz.app\")

--- a/projects/apple/tomviz.bundle.cmake
+++ b/projects/apple/tomviz.bundle.cmake
@@ -3,12 +3,6 @@ include(tomviz.bundle.common)
 set(CPACK_GENERATOR DragNDrop)
 include(CPack)
 
-if(itk_ENABLED)
-  set(itk_condition_variable 1)
-else()
-  set(itk_condition_variable 0)
-endif()
-
 install(CODE "
     # Install the app first.
     file(INSTALL DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\" USE_SOURCE_PERMISSIONS TYPE DIRECTORY FILES
@@ -32,7 +26,7 @@ install(CODE "
          USE_SOURCE_PERMISSIONS TYPE DIRECTORY FILES
          \"${install_location}/lib/python2.7/site-packages/\")
 
-    if(${itk_condition_variable})
+    if(${itk_ENABLED})
         message(\"Installing ITK\")
         file(INSTALL DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/tomviz.app/Contents/Libraries\"
              USE_SOURCE_PERMISSIONS TYPE DIRECTORY FILES


### PR DESCRIPTION
@cryos This is the right way to do it.  This is creating a subprocess cmake and running a script in it.  But the policy settings were getting lost and policy 0012 was defaulting wrong and breaking the if statement for ITK.  Only OSX should be affected since only OSX creates the bundle using a nested cmake script like this.

@mathstuf FYI.  I don't know if this might affect PVSB too since it is similar to TVSB.