### PR TITLE
Change itk libraries to not use @rpath-based paths to each other

### DIFF
--- a/projects/apple/fixup_itk.py
+++ b/projects/apple/fixup_itk.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import sys
+import commands
+import os.path
+import re
+import shutil
+
+def _getid(lib):
+  """Returns the id for the library"""
+  val = commands.getoutput("otool -D %s" % lib)
+  m = re.match(r"[^:]+:\s*([^\s]+)", val)
+  if m:
+    return m.group(1)
+  else:
+    # This happens on the python C++ code bundles
+    return None
+
+def _getlibinfo(lib):
+  Id = _getid(lib)
+  libname = os.path.basename(lib)
+  fullpath = os.path.abspath(lib)
+  return (Id, libname, fullpath)
+
+if __name__ == "__main__":
+  itk_dir = sys.argv[1]
+
+  print "------------------------------------------"
+  print "Fixing up ITK libraries"
+  print ""
+
+  libraries = commands.getoutput('find %s -type f | xargs file | grep -i "Mach-O.*" | sed "s/:.*//" | sort' % itk_dir)
+  libraries = libraries.split()
+
+  print "Found %d libraries" % len(libraries)
+
+  libinfo = [_getlibinfo(lib) for lib in libraries]
+
+  install_name_tool_args = []
+  for info in libinfo:
+    print 'Changing Id for %s' % info[2]
+    if info[0] is not None:
+      commands.getoutput('install_name_tool -id %s %s' % (info[2], info[2]))
+      install_name_tool_args += ["-change", '"%s"' % info[0], '"%s"' % info[2]]
+
+  print ''
+  install_name_tool_args = " ".join(install_name_tool_args)
+
+  for lib in libraries:
+    print 'Fixing dependencies for %s' % lib
+    commands.getoutput('install_name_tool %s %s' % (install_name_tool_args, lib))

--- a/projects/apple/tomviz.bundle.cmake
+++ b/projects/apple/tomviz.bundle.cmake
@@ -28,6 +28,9 @@ install(CODE "
          \"${install_location}/lib/python2.7/site-packages/\")
 
     if(${itk_ENABLED})
+        execute_process(
+          COMMAND ${CMAKE_CURRENT_LIST_DIR}/fixup_itk.py
+                  \"${install_location}/lib/itk\")
         message(\"Installing ITK\")
         file(INSTALL DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/tomviz.app/Contents/Libraries\"
              USE_SOURCE_PERMISSIONS TYPE DIRECTORY FILES


### PR DESCRIPTION
This should address the issues that @yijiang1 was seeing in the binaries when using ITK on OSX.  I have tested locally already, merging so that we get new working binaries sooner.