### PR TITLE
All libraries needed to load tomviz are packaged and the rpath is set

### DIFF
--- a/projects/tomviz.cmake
+++ b/projects/tomviz.cmake
@@ -1,3 +1,9 @@
+set(tomviz_extra_cmake_args)
+if (UNIX AND NOT APPLE)
+  list(APPEND tomviz_extra_cmake_args
+    -DCMAKE_INSTALL_RPATH:STRING=$ORIGIN/../lib:$ORIGIN/../lib/paraview-5.0:$ORIGIN/../lib/itk
+  )
+endif()
 add_external_project(tomviz
   DEPENDS paraview qt
 
@@ -5,6 +11,7 @@ add_external_project(tomviz
     -DBUILD_SHARED_LIBS:BOOL=ON
     -DParaView_DIR:PATH=${SuperBuild_BINARY_DIR}/paraview/src/paraview-build
     -Dtomviz_data_DIR:PATH=${tomviz_data}
+    ${tomviz_extra_cmake_args}
 
   ENABLED_DEFAULT ON
 )

--- a/projects/unix/tomviz.bundle.cmake
+++ b/projects/unix/tomviz.bundle.cmake
@@ -11,27 +11,25 @@ install(DIRECTORY "${install_location}/lib/python2.7"
   DESTINATION "lib"
   USE_SOURCE_PERMISSIONS
   COMPONENT superbuild)
+install(DIRECTORY "${install_location}/include/python2.7"
+  DESTINATION "include"
+  USE_SOURCE_PERMISSIONS
+  COMPONENT superbuild
+  PATTERN "pyconfig.h")
 
-install(CODE
-  "
-  file(GLOB shared_libs \"${install_location}/lib/*.so\")
-  message(\"\${CMAKE_INSTALL_PREFIX}/lib\")
-  foreach( lib \${shared_libs})
-    if (IS_SYMLINK \${lib})
-      get_filename_component(resolved_link \"\${lib}\" REALPATH)
-      set(lib \${resolved_link})
-    endif()
-    message(\${lib})
-    file(INSTALL \${lib}
-      DESTINATION \"\${CMAKE_INSTALL_PREFIX}/lib\"
-      USE_SOURCE_PERMISSIONS)
-  endforeach()
-  " 
-  COMPONENT superbuild)
-
-install(DIRECTORY "${install_location}/share"
+install(DIRECTORY "${install_location}/share/tomviz"
   DESTINATION "share"
   USE_SOURCE_PERMISSIONS
+  COMPONENT superbuild)
+
+install(CODE
+  "execute_process(COMMAND
+    ${CMAKE_COMMAND}
+      -Dexecutable:PATH=${install_location}/bin/tomviz
+      -Ddependencies_root:PATH=${install_location}
+      -Dtarget_root:PATH=\${CMAKE_INSTALL_PREFIX}/lib
+      -Dpv_version:STRING=${tomviz_version}
+      -P ${CMAKE_CURRENT_LIST_DIR}/install_dependencies.cmake)"
   COMPONENT superbuild)
 
 if (qt_ENABLED AND NOT USE_SYSTEM_qt)
@@ -48,6 +46,18 @@ if (qt_ENABLED AND NOT USE_SYSTEM_qt)
     PATTERN "*.jar" EXCLUDE
     PATTERN "*.debug.*" EXCLUDE
     PATTERN "libboost*" EXCLUDE)
+  install(DIRECTORY "${install_location}/share/appdata"
+    DESTINATION "share"
+    USE_SOURCE_PERMISSIONS
+    COMPONENT superbuild)
+  install(DIRECTORY "${install_location}/share/applications"
+    DESTINATION "share"
+    USE_SOURCE_PERMISSIONS
+    COMPONENT superbuild)
+  install(DIRECTORY "${install_location}/share/icons"
+    DESTINATION "share"
+    USE_SOURCE_PERMISSIONS
+    COMPONENT superbuild)
 endif()
 
 if(itk_ENABLED)


### PR DESCRIPTION
This along with OpenChemistry/tomviz#307 should get the linux binaries working.

I may have to rebuild ITK with fftw support to make them all the same though.

@cryos