### PR TITLE
Remove itk dependency on fftw3long.

### DIFF
--- a/projects/itk.cmake
+++ b/projects/itk.cmake
@@ -1,4 +1,4 @@
-set(fftw_targets fftw3double fftw3float fftw3long)
+set(fftw_targets fftw3double fftw3float)
 if (WIN32)
   set(fftw_targets fftw)
 endif()


### PR DESCRIPTION
ITK only uses fftw3double and fftw3 float.