### PR TITLE
Fixup_bundle handles Qt5 and has better argument handling

### DIFF
--- a/projects/apple/tomviz.bundle.cmake
+++ b/projects/apple/tomviz.bundle.cmake
@@ -41,9 +41,10 @@ install(CODE "
     # be 'fixed' using otool.
     execute_process(
        COMMAND ${CMAKE_CURRENT_LIST_DIR}/fixup_bundle.py
-               \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/tomviz.app\"
-               \"${install_location}/lib\"
-               \"${install_location}/plugins\")
+               --exe \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/tomviz.app\"
+               --search \"${install_location}/lib\"
+               --search \"${Qt5_DIR}/../../../lib\"
+               --plugins \"${Qt5_DIR}/../../../plugins\")
    "
    COMPONENT superbuild)
 


### PR DESCRIPTION
The fixup_bundle.py script was not handling its arguments correctly and
failing for Qt5's frameworks since there were multiple files with the
same name in the Qt5 directory.  This also modifies the argument
handling of fixup_bundle so that arguments can be more easily passed in
and modified to add new search paths.