### PR TITLE
Find dependencies after installing Qt plugins

### DIFF
--- a/projects/apple/fixup_bundle.py
+++ b/projects/apple/fixup_bundle.py
@@ -203,6 +203,17 @@ if __name__ == "__main__":
     print "    %s/%s" % (os.path.basename(App) ,os.path.relpath(exe, App))
   print ""
 
+  # If Qt Plugins dir is specified, copies those in right now.
+  # We need to fix paths on those too.
+  # Copy the plugins here so that their dependencies get pulled in.  This is needed
+  # since Qt's cocoa platform plugin depends on the QtPrintSupport framework that is
+  # otherwise not needed.
+  if QtPluginsDir:
+    print "------------------------------------------------------------"
+    print "Copying Qt plugins "
+    print "  %s ==> .../Contents/Plugins" % QtPluginsDir
+    commands.getoutput('cp -R "%s/" "%s/Contents/Plugins"' % (QtPluginsDir, App))
+
 
   # Find libraries inside the package already.
   libraries = commands.getoutput('find %s -type f | xargs file | grep -i "Mach-O.*shared library" | sed "s/:.*//" | cut -d\\  -f1 | sort' % App)
@@ -254,15 +265,6 @@ if __name__ == "__main__":
   print ""
 
   install_name_tool_command = " ".join(install_name_tool_command)
-
-  # If Qt Plugins dir is specified, copies those in right now.
-  # We need to fix paths on those too.
-  # Currently, we are not including plugins in the external dependency search.
-  if QtPluginsDir:
-    print "------------------------------------------------------------"
-    print "Copying Qt plugins "
-    print "  %s ==> .../Contents/Plugins" % QtPluginsDir
-    commands.getoutput('cp -R "%s/" "%s/Contents/Plugins"' % (QtPluginsDir, App))
 
   print "------------------------------------------------------------"
   print "Running 'install_name_tool' to fix paths to copied files."

--- a/projects/apple/tomviz.bundle.cmake
+++ b/projects/apple/tomviz.bundle.cmake
@@ -39,11 +39,13 @@ install(CODE "
 
     # at this point, the installed bundle should have the libraries that need to
     # be 'fixed' using otool.
+    # qt/plugins is needed as QtPrintSupport.framework directly links to the printsupport plugin
     execute_process(
        COMMAND ${CMAKE_CURRENT_LIST_DIR}/fixup_bundle.py
                --exe \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/tomviz.app\"
                --search \"${install_location}/lib\"
                --search \"${Qt5_DIR}/../../../lib\"
+               --search \"${Qt5_DIR}/../../../plugins\"
                --plugins \"${Qt5_DIR}/../../../plugins\")
    "
    COMPONENT superbuild)


### PR DESCRIPTION
This pulls in QtPrintSupport correctly for OSX binaries.  There is a weird issue with pulling in the qtprintsupport plugin twice, but this does generate a working bundle.