### PR TITLE
Update dependency installation rules for linux

### DIFF
--- a/projects/unix/tomviz.bundle.cmake
+++ b/projects/unix/tomviz.bundle.cmake
@@ -35,6 +35,7 @@ install(CODE
       -Ddependencies_root:PATH=${install_location}
       -Dtarget_root:PATH=\${CMAKE_INSTALL_PREFIX}/lib
       -Dpv_version:STRING=${tomviz_version}
+      -Dqt_root=${Qt5_DIR}/../../../
       -P ${CMAKE_CURRENT_LIST_DIR}/install_dependencies.cmake)"
   COMPONENT superbuild)
 


### PR DESCRIPTION
With CMake 3.5 (required by newer paraview) the get_prerequisites
function changed to error out and quit rather than return an incomplete
list of dependencies.  So we need to pass in all the locations that
dependencies are located so that it can find them all and return a list
rather than failing.

Then I had to update the logic so that it didn't install unnecessary
duplicates of libraries in the lib/paraview folder.  I made it search
for the library in the new package and only install it if it was not
found.