### PR TITLE
Update itk binaries

### DIFF
--- a/Generating_ITK_binaries.md
+++ b/Generating_ITK_binaries.md
@@ -45,54 +45,32 @@ with tomviz superbuild.
 OSX:
 ***
 
-First have a build of the superbuild without ITK built.  You need to point ITK at
-the correct numpy and fftw headers.
-Check out ITK release branch or >= 4.9 for compiling for older Mac OS X support.
+Run the `make_itk_bundle_osx.sh` script in the `itk-binaries/osx` folder.  It
+will generate the ITK tarball for OSX in the current directory assuming that your
+XCode has the appropriate SDK (currently 10.9) installed.  If you want to use a
+different SDK, you will need to modify the script to point to the SDK
+you want to build ITK with.
 
-Configure ITK with
+***
+LINUX
+***
+
+Install Docker.
+
+Go to the itk-binaries/linux folder in this repository and run the following:
+
 ```
--DBUILD_SHARED_LIBS=ON
--DITK_LEGACY_SILENT=ON
--DITK_LEGACY_REMOVE=ON
--DITK_WRAP_PYTHON=ON
--DBUILD_EXAMPLES=OFF
--DBUILD_TESTING=OFF
--DCMAKE_BUILD_TYPE=Release
--DCMAKE_INSTALL_PREFIX=temp/install/dir
--DCMAKE_OSX_ARCHITECTURES=x86_64
--DCMAKE_OSX_DEPLOYMENT_TARGET=10.8
--DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk
--DCMAKE_SKIP_INSTALL_RPATH=OFF
--DCMAKE_SKIP_RPATH=OFF
--DModule_BridgeNumPy=ON
--DNUMPY_INCLUDE_DIR=superbuild/build/dir/install/lib/python2.7/site-packages/numpy/core/include
--DITK_USE_FFTWD=ON
--DITK_USE_FFTWF=ON
--DITK_USE_SYSTEM_FFTW=ON
--DFFTWD_LIB=superbuild/build/dir/install/lib/libfftw3.a
--DFFTWD_THREADS_LIB=superbuild/build/dir/install/lib/libfftw3_threads.a
--DFFTWF_LIB=superbuild/build/dir/install/lib/libfftw3f.a
--DFFTWF_THREADS_LIB=superbuild/build/dir/install/lib/libfftw3f_threads.a
--DFFTW_INCLUDE_PATH=superbuild/build/dir/install/include
+docker build -t itk-binary-builder .
+docker run -t -i --rm itk-binary-builder
 ```
 
-Build ITK and install it to `temp/install/dir`.
+This will open a shell inside the container.  At this shell run the following:
 
-Run the following:
 ```
-cd temp/install/dir
-mkdir tmplib
-mv lib tmplib/itk
-mv tmplib lib
+cd ~
+./make_itk_bundle.sh
 ```
 
-This forces the itk installed libraries and such to install into a subfolder of
-the lib folder instead of directly into it.  This makes it easier to find what
-needs installing in the superbuild bundle creation code.
+This will generate the itk binaries to ~/dev/itk/itk-VERSION-linux-64bit.tar.gz.
+You can then use `scp` to put this file where you need the new binary to be.
 
-Then create an archive of the install dir.  Either use zip or:
-```
-tar czf my-tar-file.tar.gz install-of-itk
-```
-
-For Linux, use these instructions but leave out the CMAKE_OSX variables and the RPATH variables

--- a/itk-binaries/linux/Dockerfile
+++ b/itk-binaries/linux/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:8
+MAINTAINER Shawn Waldon <shawn.waldon@kitware.com>
+
+# Install packages
+RUN apt-get update && apt-get install -y \
+  gcc \
+  g++ \
+  gfortran \
+  python-pip \
+  python-dev \
+  git \
+  libcurl4-openssl-dev \
+  curl \
+  libxt-dev \
+  libx11-dev \
+  libglu1-mesa-dev \
+  libxext-dev \
+  libz-dev \
+  xkb-data \
+  python-virtualenv \
+  pkg-config \
+  libfontconfig1-dev
+
+RUN useradd -c buildslave -d /home/buildslave -M buildslave &&\
+    mkdir /home/buildslave &&\
+    chown buildslave:buildslave /home/buildslave
+
+COPY make_itk_bundle.sh /home/buildslave/make_itk_bundle.sh
+RUN chown buildslave:buildslave /home/buildslave/make_itk_bundle.sh && chmod +x /home/buildslave/make_itk_bundle.sh
+
+USER buildslave
+
+COPY install_cmake.sh /home/buildslave/install_cmake.sh
+RUN sh /home/buildslave/install_cmake.sh
+
+CMD /bin/bash

--- a/itk-binaries/linux/install_cmake.sh
+++ b/itk-binaries/linux/install_cmake.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+readonly cmake_version="3.5"
+readonly cmake_version_patch="2"
+readonly cmake_version_full="${cmake_version}.${cmake_version_patch}"
+
+readonly url="https://cmake.org/files/v${cmake_version}/cmake-${cmake_version_full}.tar.gz"
+
+readonly workdir="$HOME/misc/code/cmake"
+readonly srcdir="$workdir/cmake-${cmake_version_full}"
+readonly builddir="$workdir/build"
+
+mkdir -p "$builddir"
+curl "$url" | tar xz -C "$workdir"
+cd "$builddir"
+"$srcdir/bootstrap" \
+  --parallel=8 \
+  --system-curl \
+  --prefix="$HOME/misc/root/cmake"
+make -j8 install
+rm -rf "$workdir"

--- a/itk-binaries/linux/make_itk_bundle.sh
+++ b/itk-binaries/linux/make_itk_bundle.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -e
+
+readonly cmake_path=/home/buildslave/misc/root/cmake/bin
+
+readonly itk_url="git://itk.org/ITK.git"
+readonly target_tag="v4.9.0"
+
+readonly tvsb_url="https://github.com/OpenChemistry/tomviz-superbuild.git"
+
+readonly workdir="$HOME/dev/itk"
+
+readonly tvsb_dir="$HOME/dev/tvsb"
+
+mkdir -p "$tvsb_dir/build"
+git clone "${tvsb_url}" "$tvsb_dir/src"
+
+# Build a few dependencies from tomviz superbuild
+# This is to ensure that the ITK is compatible with our numpy and fftw
+cd "$tvsb_dir/build"
+$cmake_path/cmake -DENABLE_tomviz:BOOL=OFF -DENABLE_tbb:BOOL=OFF -DENABLE_pyfftw:BOOL=ON -DENABLE_numpy:BOOL=ON "$tvsb_dir/src"
+$cmake_path/cmake --build .
+
+# Build ITK
+mkdir -p "$workdir/build"
+git clone "${itk_url}" "$workdir/src"
+cd "$workdir/src"
+git checkout ${target_tag}
+cd "$workdir/build"
+$cmake_path/cmake -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DITK_LEGACY_REMOVE:BOOL=ON \
+  -DITK_LEGACY_SILENT:BOOL=ON \
+  -DITK_USE_FFTWD:BOOL=ON \
+  -DITK_USE_FFTWF:BOOL=ON \
+  -DModule_BridgeNumPy:BOOL=ON \
+  -DBUILD_TESTING:BOOL=OFF \
+  -DITK_WRAP_PYTHON:BOOL=ON \
+  -DBUILD_EXAMPLES:BOOL=OFF \
+  -DBUILD_SHARED_LIBS:BOOL=ON \
+  "-DCMAKE_INSTALL_PREFIX:PATH=$workdir/install" \
+  "-DNUMPY_INCLUDE_DIR:PATH=$tvsb_dir/build/install/lib/python2.7/site-packages/numpy/core/include" \
+  "-DFFTWD_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3.a" \
+  "-DFFTWD_THREADS_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3_threads.a" \
+  "-DFFTWF_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3f.a" \
+  "-DFFTWF_THREADS_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3f_threads.a" \
+  "-DFFTW_INCLUDE_PATH:PATH=$tvsb_dir/build/install/include" \
+  -DITK_WRAP_unsigned_short:BOOL=ON \
+  "$workdir/src"
+
+$cmake_path/cmake --build . && make install
+
+cd "$workdir/install"
+mkdir tmp
+mv lib tmp/lib
+mv tmp lib
+
+cd "$workdir"
+tar czf itk-${target_tag}-linux-64bit.tar.gz install
+
+echo "ITK binary blob created at ${workdir}/itk-${target_tag}-linux-64bit.tar.gz"

--- a/itk-binaries/osx/make_itk_bundle_osx.sh
+++ b/itk-binaries/osx/make_itk_bundle_osx.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+set -e
+
+readonly basedir=$PWD
+
+readonly cmake_path=/usr/local/bin
+
+readonly itk_url="git://itk.org/ITK.git"
+readonly target_tag="v4.9.0"
+
+readonly tvsb_url="https://github.com/OpenChemistry/tomviz-superbuild.git"
+
+readonly workdir="$basedir/dev/itk"
+
+readonly tvsb_dir="$basedir/dev/tvsb"
+
+mkdir -p "$tvsb_dir/build"
+git clone "${tvsb_url}" "$tvsb_dir/src"
+
+# Build a few dependencies from tomviz superbuild
+# This is to ensure that the ITK is compatible with our numpy and fftw
+cd "$tvsb_dir/build"
+$cmake_path/cmake -DENABLE_tomviz:BOOL=OFF -DENABLE_tbb:BOOL=OFF -DENABLE_pyfftw:BOOL=ON -DENABLE_numpy:BOOL=ON "$tvsb_dir/src"
+$cmake_path/cmake --build .
+
+# Build ITK
+mkdir -p "$workdir/build"
+git clone "${itk_url}" "$workdir/src"
+cd "$workdir/src"
+git checkout $target_tag
+cd "$workdir/build"
+$cmake_path/cmake -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DITK_LEGACY_REMOVE:BOOL=ON \
+  -DITK_LEGACY_SILENT:BOOL=ON \
+  -DITK_USE_FFTWD:BOOL=ON \
+  -DITK_USE_FFTWF:BOOL=ON \
+  -DITK_USE_SYSTEM_FFTW:BOOL=ON \
+  -DModule_BridgeNumPy:BOOL=ON \
+  -DBUILD_TESTING:BOOL=OFF \
+  -DITK_WRAP_PYTHON:BOOL=ON \
+  -DBUILD_EXAMPLES:BOOL=OFF \
+  -DBUILD_SHARED_LIBS:BOOL=ON \
+  "-DCMAKE_INSTALL_PREFIX:PATH=$workdir/install" \
+  "-DNUMPY_INCLUDE_DIR:PATH=$tvsb_dir/build/install/lib/python2.7/site-packages/numpy/core/include" \
+  "-DFFTWD_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3.a" \
+  "-DFFTWD_THREADS_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3_threads.a" \
+  "-DFFTWF_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3f.a" \
+  "-DFFTWF_THREADS_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3f_threads.a" \
+  "-DFFTW_INCLUDE_PATH:PATH=$tvsb_dir/build/install/include" \
+  -DITK_WRAP_unsigned_short:BOOL=ON \
+  -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+  -DCMAKE_OSX_DEPOLYMENT_TARGET=10.9 \
+  -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk \
+  -DCMAKE_SKIP_INSTALL_RPATH=OFF \
+  -DCMAKE_SKIP_RPATH=OFF \
+  "$workdir/src"
+
+make -j8 && make install
+
+cd "$workdir/install"
+mkdir tmp
+mv lib tmp/lib
+mv tmp lib
+
+cd "$workdir"
+tar czf itk-${target_tag}-osx-64bit.tar.gz install
+
+mv itk-${target_tag}-osx-64bit.tar.gz ${basedir}/
+
+echo "ITK binary blob created at ${basedir}/itk-${target_tag}-osx-64bit.tar.gz"

--- a/versions.cmake
+++ b/versions.cmake
@@ -157,26 +157,26 @@ if (WIN32)
   if (64bit_build)
     add_revision(itk
       URL "http://www.tomviz.org/files/itk-4.9.0-windows-64bit.zip"
-      URL_MD5 "f5642d6b96509965d98548b0e917ca36")
+      URL_MD5 "b81cba618d3be3594438d77c92aeb569")
     add_revision(fftw
       URL "http://www.tomviz.org/files/fftw-3.3.4-windows-64bit.zip"
       URL_MD5 "90ca2a2cd26c62bc85b11ec7f165e716")
   else()
     add_revision(itk
       URL "http://www.tomviz.org/files/itk-4.9.0-windows-32bit.zip"
-      URL_MD5 "718d915d0b10409da6db99bafe14a11f")
+      URL_MD5 "d832c9ca9a76acd12cb0f77db7e37e52")
     add_revision(fftw
       URL "http://www.tomviz.org/files/fftw-3.3.4-windows-32bit.zip"
       URL_MD5 "9f58e109b8e7dcdd5640f9397735dd26")
   endif()
 elseif(APPLE)
   add_revision(itk
-    URL "http://www.tomviz.org/files/itk-4.9.0-macosx10.9.tar.gz"
-    URL_MD5 "0058d4ed62893d5f12360e3d13fdf6f1")
+    URL "http://www.tomviz.org/files/itk-v4.9.0-osx-64bit.tar.gz"
+    URL_MD5 "a43736a72ef51a60698119456068dca4")
 elseif(UNIX)
   add_revision(itk
-    URL "http://www.tomviz.org/files/itk-4.9.0patched-linux-64bit.tar.gz"
-    URL_MD5 "cfcc11e1f39ae078519c30084320fbd4")
+    URL "http://www.tomviz.org/files/itk-v4.9.0-linux-64bit.tar.gz"
+    URL_MD5 "573e1dedc9e358e5b1e494ae8edc48d2")
 endif()
 
 set(tbb_ver "2017_20160916oss")


### PR DESCRIPTION
@cquammen @cryos  Updated to include ITK_WRAP_unsigned_short.

I've also added the scripts I used to generate the binaries for Linux and OSX.  I was tired of copy/pasting stuff and trying to remember what to change where.  I'm debating about the scripts for Windows.  Those have more of the directory structure that I use on my local machine hardcoded so they are less universally useful (and I'm not very good at batch scripts).