### PR TITLE
Fix structure of linux and osx itk binaries

### DIFF
--- a/itk-binaries/linux/make_itk_bundle.sh
+++ b/itk-binaries/linux/make_itk_bundle.sh
@@ -52,7 +52,7 @@ $cmake_path/cmake --build . && make install
 
 cd "$workdir/install"
 mkdir tmp
-mv lib tmp/lib
+mv lib tmp/itk
 mv tmp lib
 
 cd "$workdir"

--- a/itk-binaries/osx/make_itk_bundle_osx.sh
+++ b/itk-binaries/osx/make_itk_bundle_osx.sh
@@ -60,7 +60,7 @@ make -j8 && make install
 
 cd "$workdir/install"
 mkdir tmp
-mv lib tmp/lib
+mv lib tmp/itk
 mv tmp lib
 
 cd "$workdir"

--- a/versions.cmake
+++ b/versions.cmake
@@ -172,11 +172,11 @@ if (WIN32)
 elseif(APPLE)
   add_revision(itk
     URL "http://www.tomviz.org/files/itk-v4.9.0-osx-64bit.tar.gz"
-    URL_MD5 "a43736a72ef51a60698119456068dca4")
+    URL_MD5 "a55e2b2f63e75bf870b8e34515138d2d")
 elseif(UNIX)
   add_revision(itk
     URL "http://www.tomviz.org/files/itk-v4.9.0-linux-64bit.tar.gz"
-    URL_MD5 "573e1dedc9e358e5b1e494ae8edc48d2")
+    URL_MD5 "d1c2da71474ae49a3980d20e7784f401")
 endif()
 
 set(tbb_ver "2017_20160916oss")


### PR DESCRIPTION
@cryos I had a typo in my generate ITK binaries script... it was putting a directory in the wrong place in the binaries.  I've manually fixed the binaries and uploaded the fixed ones and fixed the scripts.