### PR TITLE
Add a flag to install the correct c runtimes on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.3)
 
+if (WIN32 AND CMAKE_VERSION VERSION_LESS 3.6.1)
+  message(FATAL_ERROR "Generating packages on Windows with Visual Studio 2015 requires a CMake version >= 3.6.1")
+endif()
+
 if(NOT WIN32)
   enable_language(Fortran)
 endif()

--- a/projects/win32/tomviz.bundle.cmake
+++ b/projects/win32/tomviz.bundle.cmake
@@ -67,6 +67,7 @@ endif()
 
 # install system runtimes.
 set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION "bin")
+set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)
 include(InstallRequiredSystemLibraries)
 include(CPack)
 


### PR DESCRIPTION
Also bump the minimum cmake version to one that supports this flag.

See [the CMake docs](https://cmake.org/cmake/help/v3.6/module/InstallRequiredSystemLibraries.html)

We'll need to update the CMake on `praxis` and the docker container before merging this.

See #138 