### PR TITLE
Selectively install only needed Qt plugins on macOS

### DIFF
--- a/projects/apple/fixup_bundle.py
+++ b/projects/apple/fixup_bundle.py
@@ -225,7 +225,9 @@ if __name__ == "__main__":
     print "------------------------------------------------------------"
     print "Copying Qt plugins "
     print "  %s ==> .../Contents/Plugins" % QtPluginsDir
-    commands.getoutput('cp -R "%s/" "%s/Contents/Plugins"' % (QtPluginsDir, App))
+    print commands.getoutput('mkdir "%s/Contents/Plugins"' % App)
+    print commands.getoutput('cp -vR "%s/printsupport" "%s/Contents/Plugins/printsupport"' % (QtPluginsDir, App))
+    print commands.getoutput('cp -vR "%s/platforms" "%s/Contents/Plugins/platforms"' % (QtPluginsDir, App))
 
 
   # Find libraries inside the package already.


### PR DESCRIPTION
@cryos I've tested this and it looks like we don't need the image plugins... the icons showed up just fine with only these changes.