### PR TITLE
Force configure not to find getentropy and clock_gettime

### DIFF
--- a/projects/python.cmake
+++ b/projects/python.cmake
@@ -1,10 +1,20 @@
+set(_proc_env "MACOSX_DEPLOYMENT_TARGET 10.9")
+
+# Horrible hack to force the configure step not to find getentropy and clock_gettime.
+# If we build on a version that has these defined ( even as weak symbols ) they will
+# be used and then we will get run time link errors when running on versions that
+# don't actually have them defined ( such as 10.11 )
+if (APPLE)
+ set(_proc_env "${_proc_env} ac_cv_func_getentropy no ac_cv_func_clock_gettime no")
+endif()
+
 add_external_project_or_use_system(python
   DEPENDS zlib
   CONFIGURE_COMMAND <SOURCE_DIR>/configure
                     --prefix=<INSTALL_DIR>
                     --enable-unicode=ucs4
                     --enable-shared
-  PROCESS_ENVIRONMENT MACOSX_DEPLOYMENT_TARGET 10.9
+  PROCESS_ENVIRONMENT ${_proc_env}
   )
 set (pv_python_executable "${install_location}/bin/python3" CACHE INTERNAL "" FORCE)
 


### PR DESCRIPTION
OK, so I think I now understand the issue we are having building Python on the Mac. 

So the problem was caused by changing our build SDK from 10.9 to 10.12. Basically that means that there are weak symbols defined on 10.12 for getentropy and clock_gettime. The python configure step is not clever enough to take into account the target min version and just sees these symbols as defined so uses them. When we try to run the built version on 10.11 the symbols are not defined so we get a runtime link error. 

This PR sets two environment variables to force the configure step to see these symbols as undefined. Its all a bit of a hack, but others have resorted to this approach. Otherwise we can just switch back to building with 10.9, I think we could use something like  https://github.com/devernay/xcodelegacy to install the old SDK.