### PR TITLE
Fix itk binaries

### DIFF
--- a/itk-binaries/linux/Dockerfile
+++ b/itk-binaries/linux/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y \
   xkb-data \
   python-virtualenv \
   pkg-config \
-  libfontconfig1-dev
+  libfontconfig1-dev \
+  vim
 
 RUN useradd -c buildslave -d /home/buildslave -M buildslave &&\
     mkdir /home/buildslave &&\

--- a/itk-binaries/linux/make_itk_bundle.sh
+++ b/itk-binaries/linux/make_itk_bundle.sh
@@ -39,6 +39,9 @@ $cmake_path/cmake -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILD_EXAMPLES:BOOL=OFF \
   -DBUILD_SHARED_LIBS:BOOL=ON \
   "-DCMAKE_INSTALL_PREFIX:PATH=$workdir/install" \
+  "-DPYTHON_LIBRARIES:FILEPATH=$tvsb_dir/build/install/lib/libpython3.6m.so" \
+  "-DPYTHON_INCLUDE_DIR:PATH=$tvsb_dir/build/install/include/python3.6m" \
+  "-DPYTHON_EXECUTABLE:FILEPATH=$tvsb_dir/build/install/bin/python3" \
   "-DNUMPY_INCLUDE_DIR:PATH=$tvsb_dir/build/install/lib/python3.6/site-packages/numpy/core/include" \
   "-DFFTWD_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3.a" \
   "-DFFTWD_THREADS_LIB:FILEPATH=$tvsb_dir/build/install/lib/libfftw3_threads.a" \
@@ -48,7 +51,7 @@ $cmake_path/cmake -DCMAKE_BUILD_TYPE:STRING=Release \
   -DITK_WRAP_unsigned_short:BOOL=ON \
   "$workdir/src"
 
-$cmake_path/cmake --build . && make install
+$cmake_path/cmake --build . -- -j8 && make install
 
 cd "$workdir/install"
 mkdir tmp

--- a/versions.cmake
+++ b/versions.cmake
@@ -130,7 +130,7 @@ else()
 endif()
 
 if (WIN32)
-  set(_itk_sha512 "f53724a3f7eb8758aded361257ec7d581e4efa0e45ee138e4b6a307b4fc2a980100fdc12c82f9ee14ed539459f2f5078a696292e1dba352edbc595b5ac4d85c3")
+  set(_itk_sha512 "de4561f2c9865633d17c63e546800504e9d991e2fefe2a23c27bf3b7d9807a118aa02dfe128af72d7bd4c452dce1dac6fdb53e67dea93963774a59b27628173a")
   add_revision(itk
     URL "http://www.tomviz.org/files/itk-4.12.0-windows-64bit.zip"
     URL_HASH SHA512=${_itk_sha512})
@@ -143,7 +143,7 @@ elseif(APPLE)
     URL "http://www.tomviz.org/files/itk-v4.12.0-osx-64bit.tar.gz"
     URL_HASH SHA512=${_itk_sha512})
 elseif(UNIX)
-  set(_itk_sha512 "0686689189b1d855ecbdbc67fab54250267a9d4cc9d57902df87f1ca3f259c0884c17511e95f64715a512b235e84d6deac4db83e2073bbfb79f6f437ba2b7432")
+  set(_itk_sha512 "39aa2bd22e1e2461656abd8983df7c4487978a5e47de006e9d8d8f3eb48c2db42fb4952d1230e3064e7241c6dd811d8a206b5e16f99fd6ee4aa861d3bd4bc8e6")
   add_revision(itk
     URL "http://www.tomviz.org/files/itk-v4.12.0-linux-64bit.tar.gz"
     URL_HASH SHA512=${_itk_sha512})


### PR DESCRIPTION
@cryos Hopefully these versions will work better.  They contain the python 3 itk modules which seem to be in the right location.

I didn't need the flags Matt and JC suggested for building on linux... that may be a Windows specific problem.  I'll try them on Windows tonight.