### PR TITLE
Fix ITK packaging on linux

### DIFF
--- a/projects/unix/tomviz.bundle.cmake
+++ b/projects/unix/tomviz.bundle.cmake
@@ -79,10 +79,13 @@ install(CODE
   COMPONENT superbuild)
 
 if(itk_ENABLED)
-install(DIRECTORY "${install_location}/lib/itk"
-        DESTINATION "lib"
-        USE_SOURCE_PERMISSIONS
-        COMPONENT superbuild)
+  install(CODE
+"
+  execute_process(COMMAND
+    ${CMAKE_COMMAND}
+    -E copy_directory ${install_location}/lib/itk \${CMAKE_INSTALL_PREFIX}/lib)
+"
+)
 endif()
 
 # install executables


### PR DESCRIPTION
`install(DIRECTORY ...)` copies the directory `itk` into `lib`, so we have `lib/itk`.  The new `INSTALL(CODE ...)` block copies the *contents* of the directory `itk` into `lib`.  Otherwise you have to do nasty things with `file(GLOB ...)` in the `install(CODE ...)` block and it gets messy.  This is the reason we make the `itk` subdirectory of `lib` in the ITK bundles, so we can make sure we install all of the ITK libraries without globbing and potentially missing some.