### PR TITLE
Update ParaView to v5.5.0-RC2

### DIFF
--- a/versions.cmake
+++ b/versions.cmake
@@ -80,7 +80,7 @@ if(USE_PARAVIEW_MASTER)
   set(_paraview_revision "master")
 else()
   # Test the revision locally before proposing a move
-  set(_paraview_revision "f700a4d7f32ccb7e31f1da6e6fd1c6188dac2feb")
+  set(_paraview_revision "v5.5.0-RC2")
 endif()
 add_revision(paraview
   GIT_REPOSITORY "https://gitlab.kitware.com/paraview/paraview.git"


### PR DESCRIPTION
@cryos 

If we want to try out building with KITS, we need this first and I want to handle the issues this brings before turning on KITS.  I had to patch the vtk module system so that KITS could be used with TBB, but I made sure the patch got into the paraview release branch.  Local testing hasn't revealed any issues yet, although we may have to adjust our hardcoded python paths in `tomviz/tomvizPython.h.in` once we see what the binaries look like (ParaView changed their install structure).

I don't think the superbuild needs to change; local testing still seems to put everything in the bundle, just in a different structure.