### PR TITLE
Update to the ParaView 5.5 release tag

### DIFF
--- a/versions.cmake
+++ b/versions.cmake
@@ -80,7 +80,7 @@ if(USE_PARAVIEW_MASTER)
   set(_paraview_revision "master")
 else()
   # Test the revision locally before proposing a move
-  set(_paraview_revision "v5.5.0-RC2")
+  set(_paraview_revision "v5.5.0")
 endif()
 add_revision(paraview
   GIT_REPOSITORY "https://gitlab.kitware.com/paraview/paraview.git"


### PR DESCRIPTION
@cjh1 I don't think we need to update the continuous builds right away since we don't depend on the new version.

cc: @cryos 