### PR TITLE
pyfftw: Do not install as a python egg

### DIFF
--- a/projects/pyfftw.cmake
+++ b/projects/pyfftw.cmake
@@ -13,6 +13,16 @@ if (UNIX AND NOT APPLE)
     LD_LIBRARY_PATH "<INSTALL_DIR>/lib")
 endif()
 
+# the --single-version-externally-managed flag gets pyfftw to install
+# as a module rather than a python egg.  But it requires an install
+# record file so I gave it one.
+set(extra_install_args)
+if (APPLE)
+  set(extra_install_args
+     --record=<INSTALL_DIR>/pyfftw_install.txt
+     --single-version-externally-managed)
+endif()
+
 add_external_project(pyfftw
   DEPENDS python numpy fftw3float fftw3double fftw3long
   CONFIGURE_COMMAND ""
@@ -24,6 +34,8 @@ add_external_project(pyfftw
   BUILD_IN_SOURCE 1
   INSTALL_COMMAND
     ${install_command_env}
-  ${pv_python_executable} setup.py install --prefix=<INSTALL_DIR>
+  ${pv_python_executable} setup.py install
+     --prefix=<INSTALL_DIR>
+     ${extra_install_args}
   ${process_environment}
 )


### PR DESCRIPTION
We found a bug in the common superbuild install python modules.... reported [here](https://gitlab.kitware.com/paraview/common-superbuild/issues/43) (I found an easy workaround for now, so I'm not taking the time to fix it).

Basically we need pyfftw to install as a module rather than as a python egg, so I used a flag for packagers to make it do that.