### PR TITLE
Add a hack to bundle the fontconfig Qt's platform plugins link to

### DIFF
--- a/projects/unix/tomviz.bundle.cmake
+++ b/projects/unix/tomviz.bundle.cmake
@@ -78,6 +78,17 @@ install(CODE
   endforeach()"
   COMPONENT superbuild)
 
+# This is a hack to install fontconfig.  The above install dependencies does not get it
+# even though it is a dependency of the libqxcb platform plugin.  We should figure out why
+# the above doesn't find and install fontconfig since this could break at some point in
+# the future.
+install(DIRECTORY "${Qt5_DIR}/../../"
+  DESTINATION "lib"
+  COMPONENT superbuild
+  FILES_MATCHING
+  PATTERN "*/" EXCLUDE
+  PATTERN "libfontconfig.so.*")
+
 if(itk_ENABLED)
   install(CODE
 "


### PR DESCRIPTION
This should be installed by calling the install dependencies script but
it is not, so we add a hack to make it install.  We should debug the
install dependencies script in future to remove the need for this.