### PR TITLE
Use the 1.3.0 release tag for Tomviz

### DIFF
--- a/versions.cmake
+++ b/versions.cmake
@@ -98,7 +98,7 @@ if (tomviz_FROM_GIT)
   # Download tomviz from GIT
   add_customizable_revision(tomviz
     GIT_REPOSITORY https://github.com/openchemistry/tomviz.git
-    GIT_TAG "master")
+    GIT_TAG "1.3.0")
 else()
   if (tomviz_FROM_SOURCE_DIR)
     add_customizable_revision(tomviz


### PR DESCRIPTION
I don't see a simple way to switch the superbuild to use this tag, but
when tagging the superbuild this should hopefully make it easier to
build this version of Tomviz if this flag is turned on from the outside.