### PR TITLE
Get the generated installer name correct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,15 @@ if(WIN32)
   endif()
 endif()
 
+# Set from the top-level so that they can be changed more easily.
+option(tomviz_FROM_GIT "If enabled Tomviz will be cloned using git" ON)
+cmake_dependent_option(tomviz_FROM_SOURCE_DIR OFF
+  "Enable to use existing tomviz source."
+  "NOT tomviz_FROM_GIT" OFF)
+
+# Force to build from a git tag for releases.
+set(tomviz_FROM_GIT ON)
+
 #-----------------------------------------------------------------------------
 include(ParaViewModules)
 include(versions)

--- a/cmake/DetermineTomvizVersion.cmake
+++ b/cmake/DetermineTomvizVersion.cmake
@@ -27,7 +27,7 @@ function(_set_version_vars versiontext)
   endif()
 endfunction()
 
-if(tomviz_FROM_SOURCE_DIR)
+if(tomviz_FROM_SOURCE_DIR AND NOT tomviz_FROM_GIT)
   # We can use GitDescribe in this case, so let's use it.
 
   # First, set the vars using the hard coded version if everything fails.

--- a/versions.cmake
+++ b/versions.cmake
@@ -89,13 +89,6 @@ add_revision(paraview
   GIT_REPOSITORY "${_paraview_repo}"
   GIT_TAG "${_paraview_revision}")
 
-option(tomviz_FROM_GIT "If enabled then the repository is fetched from git" ON)
-cmake_dependent_option(tomviz_FROM_SOURCE_DIR OFF
-  "Enable to use existing tomviz source."
-  "NOT tomviz_FROM_GIT" OFF)
-
-# Force to build from a git tag for releases.
-set(tomviz_FROM_GIT ON)
 if (tomviz_FROM_GIT)
   # Download tomviz from GIT
   add_customizable_revision(tomviz


### PR DESCRIPTION
This requires a little more coordination to generate the correct
installer name (the generated binary was correct).