### PR TITLE
Build from master/separate source again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ cmake_dependent_option(tomviz_FROM_SOURCE_DIR OFF
   "NOT tomviz_FROM_GIT" OFF)
 
 # Force to build from a git tag for releases.
-set(tomviz_FROM_GIT ON)
+# set(tomviz_FROM_GIT ON)
 
 #-----------------------------------------------------------------------------
 include(ParaViewModules)


### PR DESCRIPTION
Back to normal operation now that 1.3.0 is out.