### PR TITLE
Update sample names for new EMD sample files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,11 @@ set(CMAKE_MODULE_PATH
 
 # Download some sample data we would like to package
 set(url_prefix "https://openchemistry.org/files/temdata")
-file(DOWNLOAD ${url_prefix}/Recon_NanoParticle_doi_10.1021-nl103400a.tif
-  ${CMAKE_BINARY_DIR}/Data/Recon_NanoParticle_doi_10.1021-nl103400a.tif
+file(DOWNLOAD ${url_prefix}/Recon_NanoParticle_doi_10.1021-nl103400a.emd
+  ${CMAKE_BINARY_DIR}/Data/Recon_NanoParticle_doi_10.1021-nl103400a.emd
   EXPECTED_MD5 16dcafaaceed9bd29c2de8292bc2c7b8)
-file(DOWNLOAD ${url_prefix}/TiltSeries_NanoParticle_doi_10.1021-nl103400a.tif
-  ${CMAKE_BINARY_DIR}/Data/TiltSeries_NanoParticle_doi_10.1021-nl103400a.tif
+file(DOWNLOAD ${url_prefix}/TiltSeries_NanoParticle_doi_10.1021-nl103400a.emd
+  ${CMAKE_BINARY_DIR}/Data/TiltSeries_NanoParticle_doi_10.1021-nl103400a.emd
   EXPECTED_MD5 1191ef22b9ab570d891b14e4ee672373)
 set(tomviz_data ${CMAKE_BINARY_DIR}/Data)
 


### PR DESCRIPTION
Do we want to keep the file names exactly the same, except "emd" at the end instead of "tif"?

If so, we just need to upload the emd files, and then update the names in the binary (such as [here](https://github.com/OpenChemistry/tomviz/blob/163ea38a97b0e0a9bde1951647a253db6176faf5/tomviz/MainWindow.cxx#L589)).

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>