### PR TITLE
On Windows install, update lib/paraview/ to lib/

### DIFF
--- a/projects/win32/tomviz.bundle.cmake
+++ b/projects/win32/tomviz.bundle.cmake
@@ -25,7 +25,7 @@ install(DIRECTORY "${install_location}/share/"
         COMPONENT ${AppName})
 
 # install paraview python modules and others.
-install(DIRECTORY "${install_location}/lib/paraview"
+install(DIRECTORY "${install_location}/lib"
         DESTINATION "lib"
         USE_SOURCE_PERMISSIONS
         COMPONENT ${AppName}


### PR DESCRIPTION
The ParaView libraries are no longer installed in
`lib/paraview/`, but in `lib/`. This commit reflects
that change.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>