### PR TITLE
Upgrade ParaView version for forced static plugins

### DIFF
--- a/versions.cmake
+++ b/versions.cmake
@@ -81,7 +81,7 @@ if(USE_PARAVIEW_MASTER)
   set(_paraview_revision "master")
 else()
   # Test the revision locally before proposing a move
-  set(_paraview_revision "e18817ab55ee31a7533e84ab139ba7430e38d500")
+  set(_paraview_revision "ef655b85179c3696ec1a1019cd8494d456815a8d")
 endif()
 # Locally patched ParaView repo, or main repo
 #set(_paraview_repo "https://gitlab.kitware.com/paraview/paraview.git")


### PR DESCRIPTION
In the tomviz source code, we need to force the plugin
to be static so we can link to it. We need to upgrade
the version of ParaView for that.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>