### PR TITLE
Install Qt5 styles for Windows and Mac

### DIFF
--- a/projects/apple/tomviz.bundle.cmake
+++ b/projects/apple/tomviz.bundle.cmake
@@ -101,6 +101,7 @@ install(DIRECTORY "${superbuild_install_location}/lib/itk/python3.6/site-package
   COMPONENT superbuild)
 
 file(GLOB qt5_plugin_paths
+ "${Qt5_DIR}/../../../plugins/styles/*.dylib"
  "${Qt5_DIR}/../../../plugins/platforms/*.dylib"
  "${Qt5_DIR}/../../../plugins/printsupport/*.dylib")
 foreach (qt5_plugin_path IN LISTS qt5_plugin_paths)

--- a/projects/win32/qt.use.system.cmake
+++ b/projects/win32/qt.use.system.cmake
@@ -44,3 +44,8 @@ get_target_property(qtWindowsPluginLocation Qt5::QWindowsIntegrationPlugin LOCAT
 install(FILES ${qtWindowsPluginLocation}
         DESTINATION "bin/platforms"
         COMPONENT "tomviz")
+
+get_target_property(qtWindowsStyleLocation Qt5::QWindowsVistaStylePlugin LOCATION)
+install(FILES ${qtWindowsStyleLocation}
+        DESTINATION "bin/styles"
+        COMPONENT "tomviz")


### PR DESCRIPTION
These are required for Qt >= 5.10 to avoid making
the GUI look really old.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>