### PR TITLE
Fix win32 numpy wheel abi tag

### DIFF
--- a/projects/win32/numpy.cmake
+++ b/projects/win32/numpy.cmake
@@ -1,3 +1,3 @@
-set(numpy_platform_string "cp37-none-win_amd64")
+set(numpy_platform_string "cp37-cp37m-win_amd64")
 
 include(numpy.common)


### PR DESCRIPTION
The windows numpy wheel abi tag should be "cp37m" rather than "none" (see [here](https://pypi.org/project/numpy/1.16.4/#files)).