### PR TITLE
Fix win32 scipy wheel abi tag

### DIFF
--- a/projects/win32/scipy.cmake
+++ b/projects/win32/scipy.cmake
@@ -1,3 +1,3 @@
-set(scipy_platform_string "cp37-none-win_amd64")
+set(scipy_platform_string "cp37-cp37m-win_amd64")
 
 include(scipy.common)


### PR DESCRIPTION
The windows scipy wheel abi tag should be "cp37m" rather than
"none" (see [here](https://pypi.org/project/scipy/1.2.1/#files)).

This looks like it should be the last one. I should have noticed
and changed it with #281 (oops).