### PR TITLE
Fix Windows Python 3.7 issues

### DIFF
--- a/projects/win32/python.cmake
+++ b/projects/win32/python.cmake
@@ -10,6 +10,6 @@ add_external_project(python
 add_extra_cmake_args(
   -DPYTHON_EXECUTABLE:FILEPATH=<INSTALL_DIR>/bin/python.exe
   -DPYTHON_INCLUDE_DIR:PATH=<INSTALL_DIR>/bin/Include
-  -DPYTHON_LIBRARY:FILEPATH=<INSTALL_DIR>/bin/libs/python36.lib)
+  -DPYTHON_LIBRARY:FILEPATH=<INSTALL_DIR>/bin/libs/python37.lib)
 
 set (python_pip_executable "<INSTALL_DIR>/bin/python.exe" "-m" "pip" CACHE INTERNAL "" FORCE)

--- a/projects/win32/python.install.cmake
+++ b/projects/win32/python.install.cmake
@@ -1,3 +1,8 @@
 file(GLOB files "*")
+
+# Get rid of vcruntime*.dll, or we will install multiple copies of it
+# This fix prevents an error with WIX
+list(FILTER files EXCLUDE REGEX ".*vcruntime[0-9]+\\.dll")
+
 file(INSTALL ${files}
   DESTINATION "${install_dir}/bin/")


### PR DESCRIPTION
Update a missed "python36.lib" to "python37.lib", and prevent vcruntime*.dll from being installed from python on Windows.