### PR TITLE
Don't install ITK and Tomviz libs twice on Windows

### DIFF
--- a/projects/win32/tomviz.bundle.cmake
+++ b/projects/win32/tomviz.bundle.cmake
@@ -29,7 +29,8 @@ install(DIRECTORY "${install_location}/lib"
         DESTINATION "lib"
         USE_SOURCE_PERMISSIONS
         COMPONENT ${AppName}
-        PATTERN "*.lib" EXCLUDE)
+        PATTERN "*.lib" EXCLUDE
+        PATTERN "*.a" EXCLUDE)
 
 # install system runtimes.
 set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION "bin")

--- a/projects/win32/tomviz.bundle.cmake
+++ b/projects/win32/tomviz.bundle.cmake
@@ -31,20 +31,6 @@ install(DIRECTORY "${install_location}/lib"
         COMPONENT ${AppName}
         PATTERN "*.lib" EXCLUDE)
 
-# install tomviz Python modules and others
-install(DIRECTORY "${install_location}/lib/tomviz"
-        DESTINATION "lib"
-        USE_SOURCE_PERMISSIONS
-        COMPONENT ${AppName}
-        PATTERN "*.lib" EXCLUDE)
-
-if(itk_ENABLED)
-install(DIRECTORY "${install_location}/lib/itk"
-        DESTINATION "lib"
-        USE_SOURCE_PERMISSIONS
-        COMPONENT ${AppName})
-endif()
-
 # install system runtimes.
 set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION "bin")
 set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)


### PR DESCRIPTION
The entire `lib` directory is already installed (see [here](https://github.com/OpenChemistry/tomviz-superbuild/compare/master...psavery:fix-windows-repeated-installs?expand=1#diff-5a357763febfb1148a513d3a0d5a0cf3L28)), so we should hopefully
not need to install the `lib/tomviz` and `lib/itk` directories again.

This will hopefully fix some of the windows package bloating size (#289).
But we should probably check the Windows package and make sure ITK
still works after this gets merged and built.

We should also make sure that installing the `lib` like this doesn't result in
a `lib/lib` directory instead of just a `lib` directory. If it does, we might have
to change something...