### PR TITLE
Still seeing lib/lib issue on Windows package

### DIFF
--- a/projects/win32/tomviz.bundle.cmake
+++ b/projects/win32/tomviz.bundle.cmake
@@ -25,7 +25,7 @@ install(DIRECTORY "${install_location}/share/"
         COMPONENT ${AppName})
 
 # install paraview python modules and others.
-install(DIRECTORY "${install_location}/lib"
+install(DIRECTORY "${install_location}/lib/"
         DESTINATION "lib"
         USE_SOURCE_PERMISSIONS
         COMPONENT ${AppName}


### PR DESCRIPTION
Being a little lazy and seeing if the trailing slash missing from this
install command is the critical difference. Moving everything from
lib/lib into lib made the package work for me.