### PR TITLE
On Linux, package *libcrypt* as a dependency

### DIFF
--- a/projects/unix/install_dependencies.cmake
+++ b/projects/unix/install_dependencies.cmake
@@ -13,6 +13,16 @@ if (qt_root)
   list(APPEND dirs ${qt_root}/lib)
 endif()
 
+# This function overrides the type of a file when `get_prerequesites()`
+# is called. We will use it so that *libcrypt* will be installed along
+# with the other libraries. Otherwise, it would be considered a system
+# library, and it would not be installed.
+function(gp_resolved_file_type_override filename type)
+  if(filename MATCHES "(.*)libcrypt(.*)")
+    set(type "other" PARENT_SCOPE)
+  endif()
+endfunction()
+
 message("Determining dependencies for '${exename}'")
 get_prerequisites(
   ${executable}


### PR DESCRIPTION
Some operating systems such as fedora do not have the same version
of libcrypt. We should package libcrypt so that it can be used.

This packaging method works by overriding the type of the libcrypt file
as it is seen by `get_prerequisites()` so that it will not be ignored.