### PR TITLE
Fix windows pygments build

### DIFF
--- a/projects/pygments.cmake
+++ b/projects/pygments.cmake
@@ -13,7 +13,7 @@ add_external_project(pygments
   DEPENDS python
   CONFIGURE_COMMAND ""
   BUILD_COMMAND
-    env
+    "${CMAKE_COMMAND}" -E env
         CPPFLAGS=-I<INSTALL_DIR>/include
         LDFLAGS=-L<INSTALL_DIR>/lib
     ${pv_python_executable} setup.py build

--- a/projects/pygments.cmake
+++ b/projects/pygments.cmake
@@ -21,6 +21,5 @@ add_external_project(pygments
   INSTALL_COMMAND
     ${install_command_env}
   ${pv_python_executable} setup.py install
-     --prefix=<INSTALL_DIR>
   ${process_environment}
 )

--- a/projects/win32/python.cmake
+++ b/projects/win32/python.cmake
@@ -7,6 +7,8 @@ add_external_project(python
       "-Dinstall_dir:PATH=<INSTALL_DIR>"
       -P "${CMAKE_CURRENT_LIST_DIR}/python.install.cmake")
 
+set (pv_python_executable "${install_location}/bin/python.exe" CACHE INTERNAL "" FORCE)
+
 add_extra_cmake_args(
   -DPYTHON_EXECUTABLE:FILEPATH=<INSTALL_DIR>/bin/python.exe
   -DPYTHON_INCLUDE_DIR:PATH=<INSTALL_DIR>/bin/Include


### PR DESCRIPTION
Here are the three commits:
```
    Set pv_python_executable for windows pygment build
    
    Apparently, we haven't been building any python dependencies on
    Windows with "python setup.py build". We need this variable to
    do so. So set it in the python.cmake in the win32 directory.
```
```
    Use "${CMAKE_COMMAND}" -E env for setting env vars
    
    The "env" command is only available on unix systems. If we want
    to generalize it to work on Windows, we need to use
    "${CMAKE_COMMAND}" -E env.
```
```
    Do not specify install prefix for pygments
    
    Specifying the install prefix breaks the windows build, with it
    complaining that the install prefix is not in the python path.
    
    However, it appears to install it to the correct location without
    the install prefix. Linux also appears to install it to the
    correct location without the install prefix. Just need to make sure
    it installs to the correct location on mac, then...
```