### PR TITLE
Install pygments using pip

### DIFF
--- a/projects/pygments.cmake
+++ b/projects/pygments.cmake
@@ -20,6 +20,6 @@ add_external_project(pygments
   BUILD_IN_SOURCE 1
   INSTALL_COMMAND
     ${install_command_env}
-  ${pv_python_executable} setup.py install
+  ${python_pip_executable} install .
   ${process_environment}
 )


### PR DESCRIPTION
With "python setup.py install", the installed pygments directory
in "site-packages" has a version number and a ".egg" at the end.
It relies on the use of easypath to be found.

If we install it with "pip install ." instead, the installed
pygments directory is just named "pygments", and can be found
without easypath.

I am hoping that this will fix issues #301 and #302.