### PR TITLE
Removing as this just causes target not found

### DIFF
--- a/projects/jsonpatch.cmake
+++ b/projects/jsonpatch.cmake
@@ -6,7 +6,6 @@ endif()
 
 add_external_project(jsonpatch
   DEPENDS jsonpointer
-  ENABLED_DEFAULT ON
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   BUILD_IN_SOURCE 1

--- a/projects/marshmallow.cmake
+++ b/projects/marshmallow.cmake
@@ -9,7 +9,6 @@ set(extra_install_args
 
 add_external_project(marshmallow
   DEPENDS python
-  ENABLED_DEFAULT ON
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   BUILD_IN_SOURCE 1


### PR DESCRIPTION
I think the ENABLED_DEFAULT is pretty fragile, and keeps overrunning the
previous command. Removing for now from the two new spots, and checking
everything still builds on the dashboard machines.