### PR TITLE
Default all modules to ON

### DIFF
--- a/cmake/ParaViewModules.cmake
+++ b/cmake/ParaViewModules.cmake
@@ -103,7 +103,7 @@ macro(add_external_project _name)
     set(${cm-project}_DEPENDS_ANY "")
     set(${cm-project}_DEPENDS_OPTIONAL "")
     set(${cm-project}_CAN_USE_SYSTEM 0)
-    set(${cm-project}_ENABLED_DEFAULT OFF)
+    set(${cm-project}_ENABLED_DEFAULT ON)
     set (doing "")
 
     set (project_arguments "${ARGN}") #need quotes to keep empty list items


### PR DESCRIPTION
They are only really in here if we want them, this repo is literally
here to build binary installers... Let's see what happens when we flip
the default (parsing of keywords was way too delicate to enable some
packages).