### PR TITLE
Fix jsonpatch md5sum

### DIFF
--- a/versions.cmake
+++ b/versions.cmake
@@ -174,7 +174,7 @@ add_revision(jsonpointer
 
 add_revision(jsonpatch
   URL "https://github.com/stefankoegl/python-json-patch/archive/v1.21.zip"
-  URL_MD5 27073971f1fd0b78d63bdd29e1cdb703)
+  URL_MD5 a5aac0214434c0db6be86ea77ad8da3f)
 
 set(_holoplay_sha256 "8626082ddc89dbbd018e6113e069eb64c9f8e540db06c4c7e85162dc38b5ddad")
 add_revision(holoplay


### PR DESCRIPTION
It appears to be incorrect. I'm not sure if this suspicious behavior, or
it just needs to be fixed.