### PR TITLE
Try explicitly enabling python extraction

### DIFF
--- a/projects/paraview.cmake
+++ b/projects/paraview.cmake
@@ -36,6 +36,7 @@ add_external_project(paraview
     -DPARAVIEW_USE_QTHELP:BOOL=OFF
     -DPARAVIEW_USE_VTKM:BOOL=OFF
     -DPARAVIEW_PLUGINS_DEFAULT:BOOL=OFF
+    -DVTK_MODULE_ENABLE_ParaView_VTKExtensionsExtractionPython:STRING=YES
     # Disable for now as kits requires CMake 3.12
     #    -DPARAVIEW_ENABLE_KITS:BOOL=ON
     -DPARAVIEW_ENABLE_FFMPEG:BOOL=ON


### PR DESCRIPTION
This is being done because there are linking errors on windows
related to python extraction.

Maybe this will fix the linking issues...

The linking errors are pasted below:
```bash
[4/1554] Linking CXX shared module bin\Lib\site-packages\paraview\modules\vtkPVVTKExtensionsExtractionPython.pyd

FAILED: bin/Lib/site-packages/paraview/modules/vtkPVVTKExtensionsExtractionPython.pyd 

cmd.exe /C "cd . && C:\bbd\support\cmake-3.15.7-win64-x64\bin\cmake.exe -E vs_link_dll --intdir=CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100183~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100183~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~1\2019\COMMUN~1\VC\Tools\MSVC\1428~1.293\bin\Hostx64\x64\link.exe /nologo CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir\CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython\vtkPythonSelectorPython.cxx.obj CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir\CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython\vtkPVVTKExtensionsExtractionPythonModulePython.cxx.obj CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir\CMakeFiles\vtkPVVTKExtensionsExtractionPythonPythonPython\vtkPVVTKExtensionsExtractionPythonPythonInit.cxx.obj CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir\CMakeFiles\vtkPVVTKExtensionsExtractionPythonPythonPython\vtkPVVTKExtensionsExtractionPythonPythonInitImpl.cxx.obj  /out:bin\Lib\site-packages\paraview\modules\vtkPVVTKExtensionsExtractionPython.pyd /implib:lib\vtkPVVTKExtensionsExtractionPythonPython.lib /pdb:bin\Lib\site-packages\paraview\modules\vtkPVVTKExtensionsExtractionPython.pdb /dll /version:0.0 /machine:x64  /INCREMENTAL:NO  lib\vtkPVVTKExtensionsExtractionPython.lib lib\vtkWrappingPythonCore3.7.lib lib\vtkFiltersExtraction.lib lib\vtkFiltersGeneral.lib lib\vtkFiltersCore.lib lib\vtkCommonExecutionModel.lib lib\vtkCommonDataModel.lib lib\vtkCommonTransforms.lib C:\bbd\builds\e04ad53c\build\install\bin\libs\python37.lib lib\vtkCommonMisc.lib lib\vtkCommonMath.lib lib\vtkCommonCore.lib lib\vtksys.lib ws2_32.lib dbghelp.lib psapi.lib C:\bbd\builds\e04ad53c\build\install\lib\tbb.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib  && cd ."

LINK: command "C:\PROGRA~2\MICROS~1\2019\COMMUN~1\VC\Tools\MSVC\1428~1.293\bin\Hostx64\x64\link.exe /nologo CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir\CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython\vtkPythonSelectorPython.cxx.obj CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir\CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython\vtkPVVTKExtensionsExtractionPythonModulePython.cxx.obj CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir\CMakeFiles\vtkPVVTKExtensionsExtractionPythonPythonPython\vtkPVVTKExtensionsExtractionPythonPythonInit.cxx.obj CMakeFiles\vtkPVVTKExtensionsExtractionPythonPython.dir\CMakeFiles\vtkPVVTKExtensionsExtractionPythonPythonPython\vtkPVVTKExtensionsExtractionPythonPythonInitImpl.cxx.obj /out:bin\Lib\site-packages\paraview\modules\vtkPVVTKExtensionsExtractionPython.pyd /implib:lib\vtkPVVTKExtensionsExtractionPythonPython.lib /pdb:bin\Lib\site-packages\paraview\modules\vtkPVVTKExtensionsExtractionPython.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO lib\vtkPVVTKExtensionsExtractionPython.lib lib\vtkWrappingPythonCore3.7.lib lib\vtkFiltersExtraction.lib lib\vtkFiltersGeneral.lib lib\vtkFiltersCore.lib lib\vtkCommonExecutionModel.lib lib\vtkCommonDataModel.lib lib\vtkCommonTransforms.lib C:\bbd\builds\e04ad53c\build\install\bin\libs\python37.lib lib\vtkCommonMisc.lib lib\vtkCommonMath.lib lib\vtkCommonCore.lib lib\vtksys.lib ws2_32.lib dbghelp.lib psapi.lib C:\bbd\builds\e04ad53c\build\install\lib\tbb.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:bin\Lib\site-packages\paraview\modules\vtkPVVTKExtensionsExtractionPython.pyd.manifest" failed (exit code 1120) with the following output:

   Creating library lib\vtkPVVTKExtensionsExtractionPythonPython.lib and object lib\vtkPVVTKExtensionsExtractionPythonPython.exp

vtkPythonSelectorPython.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: static class vtkPythonSelector * __cdecl vtkPythonSelector::New(void)" (__imp_?New@vtkPythonSelector@@SAPEAV1@XZ) referenced in function "class vtkObjectBase * __cdecl PyvtkPythonSelector_StaticNew(void)" (?PyvtkPythonSelector_StaticNew@@YAPEAVvtkObjectBase@@XZ)

vtkPythonSelectorPython.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: static int __cdecl vtkPythonSelector::IsTypeOf(char const *)" (__imp_?IsTypeOf@vtkPythonSelector@@SAHPEBD@Z) referenced in function "struct _object * __cdecl PyvtkPythonSelector_IsTypeOf(struct _object *,struct _object *)" (?PyvtkPythonSelector_IsTypeOf@@YAPEAU_object@@PEAU1@0@Z)

vtkPythonSelectorPython.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: virtual int __cdecl vtkPythonSelector::IsA(char const *)" (__imp_?IsA@vtkPythonSelector@@UEAAHPEBD@Z) referenced in function "struct _object * __cdecl PyvtkPythonSelector_IsA(struct _object *,struct _object *)" (?PyvtkPythonSelector_IsA@@YAPEAU_object@@PEAU1@0@Z)

vtkPythonSelectorPython.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: static class vtkPythonSelector * __cdecl vtkPythonSelector::SafeDownCast(class vtkObjectBase *)" (__imp_?SafeDownCast@vtkPythonSelector@@SAPEAV1@PEAVvtkObjectBase@@@Z) referenced in function "struct _object * __cdecl PyvtkPythonSelector_SafeDownCast(struct _object *,struct _object *)" (?PyvtkPythonSelector_SafeDownCast@@YAPEAU_object@@PEAU1@0@Z)

vtkPythonSelectorPython.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: class vtkPythonSelector * __cdecl vtkPythonSelector::NewInstance(void)const " (__imp_?NewInstance@vtkPythonSelector@@QEBAPEAV1@XZ) referenced in function "struct _object * __cdecl PyvtkPythonSelector_NewInstance(struct _object *,struct _object *)" (?PyvtkPythonSelector_NewInstance@@YAPEAU_object@@PEAU1@0@Z)

vtkPythonSelectorPython.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: static __int64 __cdecl vtkPythonSelector::GetNumberOfGenerationsFromBaseType(char const *)" (__imp_?GetNumberOfGenerationsFromBaseType@vtkPythonSelector@@SA_JPEBD@Z) referenced in function "struct _object * __cdecl PyvtkPythonSelector_GetNumberOfGenerationsFromBaseType(struct _object *,struct _object *)" (?PyvtkPythonSelector_GetNumberOfGenerationsFromBaseType@@YAPEAU_object@@PEAU1@0@Z)

vtkPythonSelectorPython.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: virtual __int64 __cdecl vtkPythonSelector::GetNumberOfGenerationsFromBase(char const *)" (__imp_?GetNumberOfGenerationsFromBase@vtkPythonSelector@@UEAA_JPEBD@Z) referenced in function "struct _object * __cdecl PyvtkPythonSelector_GetNumberOfGenerationsFromBase(struct _object *,struct _object *)" (?PyvtkPythonSelector_GetNumberOfGenerationsFromBase@@YAPEAU_object@@PEAU1@0@Z)

vtkPythonSelectorPython.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: virtual void __cdecl vtkPythonSelector::Execute(class vtkDataObject *,class vtkDataObject *)" (__imp_?Execute@vtkPythonSelector@@UEAAXPEAVvtkDataObject@@0@Z) referenced in function "struct _object * __cdecl PyvtkPythonSelector_Execute(struct _object *,struct _object *)" (?PyvtkPythonSelector_Execute@@YAPEAU_object@@PEAU1@0@Z)

bin\Lib\site-packages\paraview\modules\vtkPVVTKExtensionsExtractionPython.pyd : fatal error LNK1120: 8 unresolved externals

[5/1554] Linking CXX shared library bin\vtkPVVTKExtensionsExtraction.dll

FAILED: bin/vtkPVVTKExtensionsExtraction.dll lib/vtkPVVTKExtensionsExtraction.lib 

cmd.exe /C "cd . && C:\bbd\support\cmake-3.15.7-win64-x64\bin\cmake.exe -E vs_link_dll --intdir=VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100183~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100183~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~1\2019\COMMUN~1\VC\Tools\MSVC\1428~1.293\bin\Hostx64\x64\link.exe /nologo VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkExtractSelectionRange.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkPConvertSelection.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkPVExtractSelection.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkPVSelectionSource.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkPVSingleOutputExtractSelection.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkQuerySelectionSource.cxx.obj  /out:bin\vtkPVVTKExtensionsExtraction.dll /implib:lib\vtkPVVTKExtensionsExtraction.lib /pdb:bin\vtkPVVTKExtensionsExtraction.pdb /dll /version:5.9 /machine:x64  /INCREMENTAL:NO  lib\vtkFiltersSources.lib lib\vtkPVVTKExtensionsExtractionPython.lib lib\vtkFiltersExtraction.lib lib\vtkParallelCore.lib lib\vtkFiltersGeneral.lib lib\vtkFiltersCore.lib lib\vtkCommonExecutionModel.lib lib\vtkCommonDataModel.lib lib\vtkCommonTransforms.lib lib\vtkCommonMisc.lib lib\vtkCommonMath.lib lib\vtkCommonCore.lib lib\vtksys.lib ws2_32.lib dbghelp.lib psapi.lib C:\bbd\builds\e04ad53c\build\install\lib\tbb.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib  && cd ."

LINK: command "C:\PROGRA~2\MICROS~1\2019\COMMUN~1\VC\Tools\MSVC\1428~1.293\bin\Hostx64\x64\link.exe /nologo VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkExtractSelectionRange.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkPConvertSelection.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkPVExtractSelection.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkPVSelectionSource.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkPVSingleOutputExtractSelection.cxx.obj VTKExtensions\Extraction\CMakeFiles\VTKExtensionsExtraction.dir\vtkQuerySelectionSource.cxx.obj /out:bin\vtkPVVTKExtensionsExtraction.dll /implib:lib\vtkPVVTKExtensionsExtraction.lib /pdb:bin\vtkPVVTKExtensionsExtraction.pdb /dll /version:5.9 /machine:x64 /INCREMENTAL:NO lib\vtkFiltersSources.lib lib\vtkPVVTKExtensionsExtractionPython.lib lib\vtkFiltersExtraction.lib lib\vtkParallelCore.lib lib\vtkFiltersGeneral.lib lib\vtkFiltersCore.lib lib\vtkCommonExecutionModel.lib lib\vtkCommonDataModel.lib lib\vtkCommonTransforms.lib lib\vtkCommonMisc.lib lib\vtkCommonMath.lib lib\vtkCommonCore.lib lib\vtksys.lib ws2_32.lib dbghelp.lib psapi.lib C:\bbd\builds\e04ad53c\build\install\lib\tbb.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:bin\vtkPVVTKExtensionsExtraction.dll.manifest" failed (exit code 1120) with the following output:

   Creating library lib\vtkPVVTKExtensionsExtraction.lib and object lib\vtkPVVTKExtensionsExtraction.exp

vtkPVExtractSelection.cxx.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: static class vtkPythonSelector * __cdecl vtkPythonSelector::New(void)" (__imp_?New@vtkPythonSelector@@SAPEAV1@XZ) referenced in function "public: static class vtkSmartPointer<class vtkPythonSelector> __cdecl vtkSmartPointer<class vtkPythonSelector>::New(void)" (?New@?$vtkSmartPointer@VvtkPythonSelector@@@@SA?AV1@XZ)

  Hint on symbols that are defined and could potentially match:

    "__declspec(dllimport) public: static class vtkDoubleArray * __cdecl vtkDoubleArray::New(void)" (__imp_?New@vtkDoubleArray@@SAPEAV1@XZ)

    "__declspec(dllimport) public: static class vtkSelection * __cdecl vtkSelection::New(void)" (__imp_?New@vtkSelection@@SAPEAV1@XZ)

    "__declspec(dllimport) public: static class vtkSelectionNode * __cdecl vtkSelectionNode::New(void)" (__imp_?New@vtkSelectionNode@@SAPEAV1@XZ)

    "__declspec(dllimport) public: static class vtkSelectionSource * __cdecl vtkSelectionSource::New(void)" (__imp_?New@vtkSelectionSource@@SAPEAV1@XZ)

bin\vtkPVVTKExtensionsExtraction.dll : fatal error LNK1120: 1 unresolved externals

```