### PR TITLE
Install Qt SVG plugins for SVG icon support

### DIFF
--- a/projects/apple/tomviz.bundle.cmake
+++ b/projects/apple/tomviz.bundle.cmake
@@ -148,10 +148,7 @@ install(DIRECTORY "${superbuild_install_location}/lib/itk/python3.7/site-package
   DESTINATION "tomviz.app/Contents/Python/itk/"
   COMPONENT superbuild)
 
-file(GLOB qt5_plugin_paths
- "${Qt5_DIR}/../../../plugins/styles/*.dylib"
- "${Qt5_DIR}/../../../plugins/platforms/*.dylib"
- "${Qt5_DIR}/../../../plugins/printsupport/*.dylib")
+file(GLOB qt5_plugin_paths "${Qt5_DIR}/../../../plugins/*/*.dylib")
 foreach (qt5_plugin_path IN LISTS qt5_plugin_paths)
   get_filename_component(qt5_plugin_group "${qt5_plugin_path}" DIRECTORY)
   get_filename_component(qt5_plugin_group "${qt5_plugin_group}" NAME)
@@ -161,7 +158,7 @@ foreach (qt5_plugin_path IN LISTS qt5_plugin_paths)
     "tomviz.app"
     "${qt5_plugin_path}"
     "Contents/Plugins/${qt5_plugin_group}"
-    SEARCH_DIRECTORIES  "${library_paths}")
+    SEARCH_DIRECTORIES "${library_paths}")
 endforeach ()
 
 add_test(GenerateTomvizPackage

--- a/projects/win32/qt.use.system.cmake
+++ b/projects/win32/qt.use.system.cmake
@@ -40,12 +40,16 @@ foreach(dir IN LISTS qt5_libdirs)
 endforeach()
 " COMPONENT "tomviz")
 
-get_target_property(qtWindowsPluginLocation Qt5::QWindowsIntegrationPlugin LOCATION)
-install(FILES ${qtWindowsPluginLocation}
-        DESTINATION "bin/platforms"
-        COMPONENT "tomviz")
 
-get_target_property(qtWindowsStyleLocation Qt5::QWindowsVistaStylePlugin LOCATION)
-install(FILES ${qtWindowsStyleLocation}
-        DESTINATION "bin/styles"
-        COMPONENT "tomviz")
+function(install_qt5_plugin plugin destination)
+  get_target_property(plugin_location ${plugin} LOCATION)
+  install(FILES ${plugin_location}
+          DESTINATION ${destination}
+          COMPONENT "tomviz")
+endfunction()
+
+install_qt5_plugin(Qt5::QWindowsIntegrationPlugin "bin/platforms")
+install_qt5_plugin(Qt5::QWindowsVistaStylePlugin "bin/styles")
+install_qt5_plugin(Qt5::QSvgIconPlugin "bin/iconengines")
+install_qt5_plugin(Qt5::QSvgPlugin "bin/imageformats")
+install_qt5_plugin(Qt5::QSQLiteDriverPlugin "bin/sqldrivers")


### PR DESCRIPTION
Otherwise, tomviz will be unable to use SVG icons, which are the
majority of the icons...

Linux already installs all plugins, so it does not need to be changed.
This commit gets Mac to also install all plugins, and it adds the
needed ones to Windows.