### PR TITLE
Fix Mac and Windows Qt plugins

### DIFF
--- a/projects/apple/tomviz.bundle.cmake
+++ b/projects/apple/tomviz.bundle.cmake
@@ -148,7 +148,13 @@ install(DIRECTORY "${superbuild_install_location}/lib/itk/python3.7/site-package
   DESTINATION "tomviz.app/Contents/Python/itk/"
   COMPONENT superbuild)
 
-file(GLOB qt5_plugin_paths "${Qt5_DIR}/../../../plugins/*/*.dylib")
+file(GLOB qt5_plugin_paths
+ "${Qt5_DIR}/../../../plugins/styles/*.dylib"
+ "${Qt5_DIR}/../../../plugins/platforms/*.dylib"
+ "${Qt5_DIR}/../../../plugins/iconengines/*.dylib"
+ "${Qt5_DIR}/../../../plugins/imageformats/*.dylib"
+ "${Qt5_DIR}/../../../plugins/sqldrivers/libqsqlite.dylib"
+ "${Qt5_DIR}/../../../plugins/printsupport/*.dylib")
 foreach (qt5_plugin_path IN LISTS qt5_plugin_paths)
   get_filename_component(qt5_plugin_group "${qt5_plugin_path}" DIRECTORY)
   get_filename_component(qt5_plugin_group "${qt5_plugin_group}" NAME)

--- a/projects/win32/qt.use.system.cmake
+++ b/projects/win32/qt.use.system.cmake
@@ -13,6 +13,7 @@ set(tomvizQt5Libs
   Network
   Widgets
   Sql
+  Svg
   Test
   UiTools
   Xml)


### PR DESCRIPTION
Mac was producing an error when trying to fixup some of the plugins
it was trying to install. Specifically, it produced an error for a
debug library of libqsqlite. Thus, we should specify all the plugins
we want directly to avoid these errors.

For Windows, we need to find QSvg to use the targets.