### PR TITLE
Create a nightly pre-release with GitHub Actions

### DIFF
--- a/.github/scripts/create_nightly_date.sh
+++ b/.github/scripts/create_nightly_date.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Get the date for yesterday (which is what the nightly would have
+# been generated for).
+
+if [[ $RUNNER_OS == "macOS" ]]; then
+  # Mac has a slightly different date than Linux
+  NIGHTLY_DATE=$(date -v -1d '+%m-%d-%Y')
+else
+  NIGHTLY_DATE=$(date '+%m-%d-%Y' -d 'yesterday')
+fi
+
+echo "NIGHTLY_DATE=$NIGHTLY_DATE" >> $GITHUB_ENV

--- a/.github/scripts/delete_nightly_release.sh
+++ b/.github/scripts/delete_nightly_release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# If there is a "Nightly" release and a "nightly" tag that were not made
+# today, delete them. A new one will be uploaded in a later step.
+
+# Turn off errors in case the nightly doesn't exist
+set +e
+
+# Enter the superbuild directory
+cd tomviz-superbuild
+
+# We apparently have to set this environment variable to any value to use hub
+# See https://github.com/github/hub/issues/2149
+export GITHUB_USER=openchemistry
+
+# Check if today's nightly release has already been created
+hub_output=$(hub release show nightly)
+
+echo "hub_output is: $hub_output"
+echo "NIGHTLY_DATE is $NIGHTLY_DATE"
+
+# This should have the nightly date in its body if it was made today.
+if [[ ! -z "$hub_output" ]] && [[ "$hub_output" != *"$NIGHTLY_DATE"* ]]; then
+  echo "Deleting previous nightly"
+
+  # It has not already been created. Delete the old one, if present.
+  hub release delete Nightly
+  hub push origin nightly --delete
+  git tag -d nightly
+else
+  echo "Not deleting nightly (either it did not exist or it is up-to-date"
+fi
+
+exit 0

--- a/.github/scripts/rename_packages_to_latest.sh
+++ b/.github/scripts/rename_packages_to_latest.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Rename all "Tomviz-*.<ext>" packages to "tomviz-latest.<ext>"
+
+for f in ./build/Tomviz-*; do
+  filename=$(basename $f)
+  extension=${filename##*.}
+
+  if [[ "$extension" == "gz" ]]; then
+    # This should actually be tar.gz on Linux
+    extension="tar.gz"
+  fi
+
+  target="./build/tomviz-latest.$extension"
+  echo "Moving $f to $target"
+  mv $f $target
+done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
     tags: ['*']
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   build-package:
@@ -200,4 +202,17 @@ jobs:
         name: Tomviz-${{ steps.describe.outputs.version }}.${{ matrix.config.package }}
         path: ${{ github.workspace }}/build/Tomviz*.${{ matrix.config.package }}
 
+    - name: Create nightly date
+      if: github.event.schedule == '0 0 * * *'
+      run: bash tomviz-superbuild/.github/scripts/create_nightly_date.sh
 
+    - name: Upload nightly
+      if: github.event.schedule == '0 0 * * *'
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Nightly for "${{ env.NIGHTLY_DATE }}"
+        tag_name: "Nightly_${{ env.NIGHTLY_DATE }}"
+        prerelease: true
+        files: |
+          ${{ github.workspace }}/build/Tomviz*.${{ matrix.config.package }}
+          ${{ github.workspace }}/build/Tomviz*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,3 +216,24 @@ jobs:
         files: |
           ${{ github.workspace }}/build/Tomviz*.${{ matrix.config.package }}
           ${{ github.workspace }}/build/Tomviz*.zip
+
+    - name: Remove latest nightly
+      if: github.event.schedule == '0 0 * * *'
+      env:
+        # Expose the GitHub token for hub to use it
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: bash tomviz-superbuild/.github/scripts/delete_nightly_release.sh
+
+    - name: Rename packages to latest
+      if: github.event.schedule == '0 0 * * *'
+      run: bash tomviz-superbuild/.github/scripts/rename_packages_to_latest.sh
+
+    - name: Upload latest nightly
+      if: github.event.schedule == '0 0 * * *'
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Nightly
+        body: Nightly for "${{ env.NIGHTLY_DATE }}"
+        tag_name: "nightly"
+        prerelease: true
+        files: ${{ github.workspace }}/build/tomviz-latest.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,8 +232,8 @@ jobs:
       if: github.event.schedule == '0 0 * * *'
       uses: softprops/action-gh-release@v1
       with:
-        name: Nightly
+        name: Latest
         body: Nightly for "${{ env.NIGHTLY_DATE }}"
-        tag_name: "nightly"
+        tag_name: "latest"
         prerelease: true
         files: ${{ github.workspace }}/build/tomviz-latest.*


### PR DESCRIPTION
This should create and upload a new pre-release every night using the latest Tomviz.

This is the same as #335, which was accidentally closed (and apparently can't be re-opened for some reason).