### PR TITLE
Add initial logic for dispatching release workflow

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Make the release directory, which will contain everything to be uploaded
+mkdir release
+
+if [[ $RUNNER_OS == "Linux" ]]; then
+  # Add "-Linux" to the name before the extension, to avoid a name
+  # clash with the source tarball.
+  tarball_file=$(ls build/Tomviz*.tar.gz)
+  tarball_basename=$(basename $tarball_file)
+  # Since we know the extension is 7 characters, just remove the last 7 characters
+  without_extension="${tarball_basename::-7}"
+  new_name=$without_extension-Linux.tar.gz
+  mv $tarball_file build/$new_name
+
+  # Make the source tarball and prepare it to be uploaded
+  # We will use the same name as "without_extension", except lowercase the t
+  source_name=t${without_extension:1}
+
+  # Ensure all submodules are present, and remove all `.git` folders
+  mkdir source-tarball
+  pushd .
+  cd source-tarball
+  git clone --recursive --depth 1 https://github.com/openchemistry/tomviz $source_name
+
+  # Remove all .git folders
+  find . -name ".git" | xargs rm -rf
+
+  # Create the tarball
+  tar -czf $source_name.tar.gz $source_name
+
+  # Move it to the release directory
+  mv $source_name.tar.gz ../release
+  popd
+fi
+
+# Move all Tomviz* files to the release directory
+mv build/Tomviz* release/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
     branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      tomviz_release_tag:
+        description: 'The Tomviz tag to use (for releases)'
+        required: true
 
 jobs:
   build-package:
@@ -67,7 +72,8 @@ jobs:
         fetch-depth: 0
         submodules: true
         repository: OpenChemistry/tomviz
-        ref: master
+        # If the tomviz tag was provided, use that. Otherwise, use master.
+        ref: ${{ github.event.inputs.tomviz_release_tag || 'master' }}
         path: tomviz
 
     - name: Install Qt
@@ -237,3 +243,15 @@ jobs:
         tag_name: "latest"
         prerelease: true
         files: ${{ github.workspace }}/build/tomviz-latest.*
+
+    - name: Prepare release
+      if: github.event_name == 'workflow_dispatch'
+      run: bash tomviz-superbuild/.github/scripts/prepare_release.sh
+
+    - name: Upload release
+      if: github.event_name == 'workflow_dispatch'
+      uses: softprops/action-gh-release@v1
+      with:
+        name: ${{ github.event.inputs.tomviz_release_tag }}
+        tag_name: ${{ github.event.inputs.tomviz_release_tag }}
+        files: ${{ github.workspace }}/release/*


### PR DESCRIPTION
The way a release is planned to be created is:

1. The user triggers a manual GitHub Actions workflow
2. The workflow will ask for the tomviz release tag to use
3. The workflow will run using this release tag, and will create release files and upload them to a tomviz-superbuild release on GitHub

The goal is to automate as much of the release process as possible. There will still be some manual steps afterward (including notarization on the Mac). This will all be documented.