### PR TITLE
Install gfortran-9 for mac CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
             generator: 'Unix Makefiles',
             c: 'clang',
             cxx: 'clang++',
-            fc: 'gfortran-10',
+            fc: 'gfortran-9',
             cmake: 'cmake',
             ctest: 'ctest'
           }
@@ -113,6 +113,11 @@ jobs:
       if: ${{ matrix.config.name == 'MacOSX'}}
       run: |
           sudo ln -s /usr/local/opt/openssl@1.1  /usr/local/ssl
+
+    - name: Install gfortan-9 (MacOSX)
+      if: ${{ matrix.config.name == 'MacOSX'}}
+      run: |
+          brew install gcc@9
 
     - name: Make build directory
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
             generator: 'Unix Makefiles',
             c: 'clang',
             cxx: 'clang++',
-            fc: 'gfortran-9',
+            fc: 'gfortran-10',
             cmake: 'cmake',
             ctest: 'ctest'
           }


### PR DESCRIPTION
It appears that gfortran-9 was removed recently:

https://github.com/actions/runner-images/commit/3c5dc9d3a7d0a9b562464587ff9e243ca3094801

The Mac CI has been failing. Maybe this is the reason.